### PR TITLE
Fix for v12 grid field warnings

### DIFF
--- a/system.json
+++ b/system.json
@@ -37,6 +37,10 @@
   "download": "https://github.com/drl2/ezd6-fvtt/releases/latest/download/system.zip",
   "gridDistance": 5,
   "gridUnits": "ft",
+  "grid": {
+    "distance": 5,
+    "units": "ft"
+  },
   "primaryTokenAttribute": "strikes",
   "secondaryTokenAttribute": "karma"
 }


### PR DESCRIPTION
The following warnings appear when using using Foundry v12:

```
The system "ezd6" is using "gridDistance" which is deprecated in favor of "grid.distance".
The system "ezd6" is using "gridUnits" which is deprecated in favor of "grid.units".
```

This should fix that while maintaining compatibility with v11 and prior versions. The old "gridDistance" and "gridUnits" fields can be removed once capability with versions prior to v12 is removed.